### PR TITLE
Added Name method to datacenter.go

### DIFF
--- a/object/datacenter.go
+++ b/object/datacenter.go
@@ -41,6 +41,17 @@ func NewDatacenter(c *vim25.Client, ref types.ManagedObjectReference) *Datacente
 	}
 }
 
+func (d Datacenter) Name(ctx context.Context) (string, error) {
+	var dc mo.Datacenter
+
+	err := d.Properties(ctx, d.Reference(), []string{"name"}, &dc)
+	if err != nil {
+		return "", err
+	}
+
+	return dc.Name, nil
+}
+
 func (d *Datacenter) Folders(ctx context.Context) (*DatacenterFolders, error) {
 	var md mo.Datacenter
 


### PR DESCRIPTION
Datacenter is missing the Name() function that is present in other wrappers such as VirtualMachine and Datastore.  The inconsistency can be confusing, and getting the datacenter name is a common enough operation to deserve its own method.
